### PR TITLE
Get yo swag on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ target/
 
 # PostgresQL
 pg_data/
+
+# Compiled Swagger Spec
+swagger.yaml

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ clean:
 	# Delete built binaries
 	rm -rf $(BUILD_DIR)
 
+swagger:
+	# Generate full Swagger API spec output file
+	./swaggregate.py -m main.yaml -o swagger.yaml
+
 .PHONY: clean all
 .PHONY: $(BINARIES)
 .PHONY: $(APPS)

--- a/main.yaml
+++ b/main.yaml
@@ -1,0 +1,33 @@
+---
+#include: metrics/metrics.yaml
+swagger: '2.0'
+info:
+  title: Torque API
+  description: API for all things fitness-y
+  version: '1.0.0'
+# the domain of the service
+host: torque.com
+# array of all supported schemes
+schemes:
+  - https
+produces:
+  - application/json
+parameters:
+  pageParam:
+    name: page
+    type: integer
+    format: int32
+    in: query
+    required: false
+    description: The page of a paginated result to retrieve
+paths: []
+definitions:
+  Error:
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string

--- a/main.yaml
+++ b/main.yaml
@@ -20,7 +20,7 @@ parameters:
     in: query
     required: false
     description: The page of a paginated result to retrieve
-paths: []
+paths: {}
 definitions:
   Error:
     properties:

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -1,0 +1,74 @@
+---
+tags:
+  - metrics
+  - bodyweight
+paths:
+  /metrics/bodyweight:
+    get:
+      summary: Get a Bodyweight measurement resource
+      description: Retrieve a specified bodyweight resource
+      responses:
+        200:
+          description: A Bodyweight resoure
+          schema:
+            $ref: '#/definitions/Bodyweight'
+        404:
+          description: No such Bodyweight
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+            description: Unexpected error
+            schema:
+              $ref: '#/definitions/Error'
+    put:
+      summary: Update an exiting Bodyweight measurement resource
+      description: Update a specified bodyweight resource
+      responses:
+        200:
+          description: A Bodyweight resoure
+          schema:
+            $ref: '#/definitions/Bodyweight'
+        404:
+          description: No such Bodyweight
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+            description: Unexpected error
+            schema:
+              $ref: '#/definitions/Error'
+    post:
+      summary: Create a new Bodyweight measurement resource
+      description: Create a new bodyweight resource
+      responses:
+        200:
+          description: A Bodyweight resoure
+          schema:
+            $ref: '#/definitions/Bodyweight'
+        default:
+            description: Unexpected error
+            schema:
+              $ref: '#/definitions/Error'
+    delete:
+      summary: Delete an exiting Bodyweight measurement resource
+      description: Delete a specified bodyweight resource
+      responses:
+        200:
+          description: Nothing
+          schema:
+            $ref: '#/definitions/Bodyweight'
+        default:
+            description: Unexpected error
+            schema:
+              $ref: '#/definitions/Error'
+definitions:
+  Bodyweight:
+    properties:
+      timestamp:
+        type: string
+        description: The time that this measurement was taken
+      weight:
+        type: float64
+        description: The bodyweight measured
+      comment:
+        type: string
+        description: An optional comment associated with this bodyweight measurement

--- a/swaggregate.py
+++ b/swaggregate.py
@@ -16,9 +16,9 @@ def extract_includes(filepath='main.yaml'):
     includes = []
     include_stmt = '#include:'
     with open(filepath) as f:
-        comment_lines = [l for l in f if l.startswith('#')]
+        comment_lines = (l for l in f if l.startswith('#'))
         for line in comment_lines:
-            if include_stmt in line:
+            if line.startswith(include_stmt):
                 includes.append(line.replace(include_stmt, '').strip())
     return includes
 

--- a/swaggregate.py
+++ b/swaggregate.py
@@ -1,0 +1,151 @@
+import argparse
+import logging
+import yaml
+
+LOGGER = logging.getLogger(__name__)
+
+
+def extract_includes(filepath='main.yaml'):
+    """Given the provided *filepath*, load the list of swaggregator include
+    statements, in the order that they appear in *filepath*
+
+    :param filepath: The path to the swaggregator compliant yaml file
+    :return: A :const:`list` of swagger files to include
+    """
+    includes = []
+    include_stmt = '#include:'
+    with open(filepath) as f:
+        comment_lines = [l for l in f if l.startswith('#')]
+        for line in comment_lines:
+            if include_stmt in line:
+                includes.append(line.replace(include_stmt, '').strip())
+    return includes
+
+
+class SwaggerSpec:
+    """A object representation of a swagger API specification namespace. Adds
+    support to the swagger spec language to add the use of "include" statements
+    in your swagger spec file.
+    ```
+    ---
+    #include: other_package/swagger.yaml
+    swagger: '2.0'
+    ```
+    Included specification files will have an "in-order" precedence (ie, the
+    last include statement could override attributes of the same name included
+    from spec files that were included earlier).
+
+    Currently, there is support for merging `tags`, `schemes`, `produces`,
+    `parameters`, `paths`, and `definitions` from included spec files into the
+    namespace of a SwaggerSpec instance
+    """
+
+    # Assortment of attributes to attempt to import into this specifications
+    # namespace when loading included spec files.
+    __attrs__ = [
+        ('tags', list),
+        ('schemes', list),
+        ('produces', list),
+        ('parameters', dict),
+        ('paths', dict),
+        ('definitions', dict)
+    ]
+
+    def __init__(self, spec='main.yaml'):
+        """Create a new SwaggerSpec instance based off of the root
+        specification from the file specified by *spec*
+
+        :param spec: The swagger spec file entry point
+        """
+        super(SwaggerSpec, self).__init__()
+        self._spec = spec
+
+        # Set our attributes to safe defaults in case the main swagger spec
+        # doesn't specify them
+        for key, typ in self.__attrs__:
+            setattr(self, key, typ())
+
+        raw_data = self.load(spec)
+        # Load our main swagger file's specification into this instance
+        for k, v, in raw_data.items():
+            setattr(self, k, v)
+
+    def load_includes(self):
+        """Load include statements and register them into this namespace"""
+        includes = extract_includes(self.spec)
+        for include in includes:
+            self._include(include)
+
+    def _include(self, include):
+        """Recursive include method used to recursively include any
+        specification files
+        """
+        self.merge(include)
+        includes = extract_includes(include)
+        for include in includes:
+            self._include(include)
+
+    def merge(self, include):
+        """Merge the data stored in the *include* spec file, into our current
+        SwaggerSpec instance
+        """
+        data = self.load(include)
+        for key, typ in self.__attrs__:
+            if typ is dict:
+                self.__dict__[key].update(data.get(key, typ()))
+            else:
+                self.__dict__[key] += data.get(key, typ())
+
+    def load(self, filepath='main.yaml'):
+        """Load the main swaggregator file entry point
+
+        :param filepath: The path to the main swaggregator entry point
+        :return: The loaded yaml contents of *filepath* as a :const:`dict`
+        """
+        with open(filepath) as f:
+            return yaml.load(f)
+
+    def output(self, filepath):
+        """Write the contents of this SwaggerSpec instance to *filepath*
+
+        :param filepath: The path to the file to output the fully compiled spec
+            out to
+        """
+        with open(filepath, 'w') as f:
+            f.write(self.__yaml__())
+
+    def __yaml__(self):
+        """Express this SwaggerSpec instance as a YAML string"""
+        data = {k: self.__dict__[k] for k in self.__dict__
+                if not k.startswith('_')}
+        return yaml.dump(data, default_flow_style=False)
+
+
+def parse_args():
+    """Parse commandline arguments and return the namespace they are compiled
+    in by the ArgumentParser
+    """
+    parser = argparse.ArgumentParser(
+        description='Aggregate swagger spec files rom multiple, local packages'
+    )
+
+    parser.add_argument('-m', '--main', action='store', default='main.yaml',
+                       help='The main swagger file to load.')
+    parser.add_argument('-o', '--out', action='store', default='output.yaml',
+                       help='The name of the yaml file to output to.')
+    return parser.parse_args()
+
+
+def main():
+    """Main function. Parses commandline arguments, creates a SwaggerSpec
+    instance, loads all of the included spec files, and then outputs
+    """
+    args = parse_args()
+    spec = SwaggerSpec(args.main)
+    spec.load_includes()
+    spec.output(args.out)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/swaggregate.py
+++ b/swaggregate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import logging
 import yaml
@@ -72,7 +73,7 @@ class SwaggerSpec:
 
     def load_includes(self):
         """Load include statements and register them into this namespace"""
-        includes = extract_includes(self.spec)
+        includes = extract_includes(self._spec)
         for include in includes:
             self._include(include)
 


### PR DESCRIPTION
We'll probably hash out whether we should be using swaggregate or not, but I'm voting yes. Mainly because, at least for now, it'll let us modularize our swagger specs. Then we can compile and test them as a whole.

I should probably upload swaggregate as it's own PyPi package, but I want to add a few more things to it first. Eventually we can make that happen.

Adds a `make swagger` rule that runs swaggregate and if you read `main.yaml` you can see how to include local spec files
